### PR TITLE
add discriminator signatures for `isFoo` utilities

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+[*.{js,jsx,ts,tsx}]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# IDE 
+.alm/

--- a/src/chain.ts
+++ b/src/chain.ts
@@ -40,7 +40,7 @@ let ChainClassContructor = (input: any) => {
     if (input instanceof Chainable) {
         return input;
     }
-    
+
     let instance: Object = {};
     // if that's function'
     if (utils.isFunction(input)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export {Each as each} from './each';
-export {Chain as chain, Chainable} from './chain';
-export {Utils as utils }  from './utils';
+export { Each as each } from './each';
+export { Chain as chain, Chainable } from './chain';
+export { Utils as utils } from './utils';

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -14,10 +14,13 @@
         "noLib": false,
         "outDir": "../build",
         "preserveConstEnums": true,
-        "suppressImplicitAnyIndexErrors": true
+        "suppressImplicitAnyIndexErrors": true,
+        "lib": [
+          "dom",
+          "es6"
+        ]
     },
     "exclude": [
-       
     ],
     "compileOnSave": false,
     "buildOnSave": false,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,7 @@ const genTag = '[object GeneratorFunction]';
 export class Utils {
 
   // isPromise()
-  static isPromise(item: any) {
+  static isPromise(item: any): item is Promise<any> {
     return item
       && typeof item.then === 'function' &&
       typeof item.catch === 'function';
@@ -24,27 +24,27 @@ export class Utils {
     return input === undefined || input === null;
   }
 
-  static isMap(input: any) {
+  static isMap(input: any): input is Map<any,any> {
     if (typeof Map === "undefined") {
       return false;
     }
     return input instanceof Map;
   }
 
-  static isSet(input: any) {
+  static isSet(input: any): input is Set<any> {
     if (typeof Set === "undefined") {
       return false;
     }
     return input instanceof Set;
   }
 
-  static isFunction(value: any) {
+  static isFunction(value: any): value is Function {
     var tag = this.isObject(value) ? objectToString.call(value) : '';
     return tag === funcTag2 || tag == funcTag || tag == genTag;
   }
 
   //isObject
-  static isObject(input: any) {
+  static isObject(input: any): input is Object {
     var type = typeof input;
     return !!input && (type == 'object' || type == 'function');
   }
@@ -89,12 +89,12 @@ export class Utils {
     return value;
   }
 
-  static isString(value: any) {
+  static isString(value: any): value is string {
     return typeof value === 'string';
   }
 
   // isArray
-  static isArray(input: any) {
+  static isArray(input: any): input is Array<any> {
     return Array.isArray(input);
   }
 


### PR DESCRIPTION
@nchanged Main reason : So that we don't need to use assertions in FuseBox e.g. `isString(foo)` should tell TypeScript that the value is a string and we don't need to do `foo as string` anymore. 

Let me know when its published / any issues in publishing and then I will go ahead and send a PR to fusebox to use this :rose: